### PR TITLE
Add support for CpH and vCpH models, but unfortunately they do not work

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,6 +9,8 @@ in
 At present the *only* supported models are:
 
  - `agnslim`
+ - `cluscool`
+ - `vcluscool`
  - `zkerrbb`
 
 and there has been *essentially no testing* to check this works

--- a/setup.py
+++ b/setup.py
@@ -79,6 +79,8 @@ mod = Extension('xspeclmodels._models',
                 library_dirs=libs,
                 libraries=libnames,
                 sources=['src/xspeclmodels/src/_models.cxx',
+                         'src/xspeclmodels/src/cluscool.cxx',
+                         'src/xspeclmodels/src/vcluscool.cxx',
                          'src/xspeclmodels/src/zkerrbb.cxx'],
                 extra_objects=fobjs,
                 # , extra_link_args=['-lgfortran']

--- a/src/xspeclmodels/__init__.py
+++ b/src/xspeclmodels/__init__.py
@@ -5,6 +5,8 @@
 """
 Sherpa interface to XSPEC local models:
     agnslim
+    cluscool
+    vcluscool
     zkerrbb
 
 agnslim     14      0.03       1.e20          agnslim  add  0
@@ -22,6 +24,31 @@ R_warm      "Rg"         20.0       2         2       500      500	        0.1
 logrout     "(-selfg) "  -1.0      -3.0      -3.0       7.0      7.0       -1e-2
 rin         ""           -1        -1        -1       100.     100.        -1
 redshift    " "           0.0       0.        0.        5        5         -1
+
+CpH     4   0.        1.e20           C_cph   add  0
+peakT    keV     2.2       1.0e-1  1.0e-1   1.0e2       1.0e2       0.001
+Abund    " "     1.       0.      0.       1000.       1000.       -0.01
+Redshift " "     0.       1.0e-6  1.0e-6   50.         50.       -0.01
+$switch    1
+
+vCpH    17  0.         1.e20           C_vcph   add  0
+peakT   keV     2.2       1.0e-1  1.0e-1   1.0e2       1.0e2       0.001
+He       " "    1.    0.      0.   1000.     1000.       -0.01
+C        " "    1.    0.      0.   1000.     1000.       -0.01
+N        " "    1.    0.      0.   1000.     1000.       -0.01
+O        " "    1.    0.      0.   1000.     1000.       -0.01
+Ne       " "    1.    0.      0.   1000.     1000.       -0.01
+Na       " "    1.    0.      0.   1000.     1000.       -0.01
+Mg       " "    1.    0.      0.   1000.     1000.       -0.01
+Al       " "    1.    0.      0.   1000.     1000.       -0.01
+Si       " "    1.    0.      0.   1000.     1000.       -0.01
+S        " "    1.    0.      0.   1000.     1000.       -0.01
+Ar       " "    1.    0.      0.   1000.     1000.       -0.01
+Ca       " "    1.    0.      0.   1000.     1000.       -0.01
+Fe       " "    1.    0.      0.   1000.     1000.       -0.01
+Ni       " "    1.    0.      0.   1000.     1000.       -0.01
+Redshift " "    0.    1.0e-6  1.0e-6 50.       50.       -0.01
+$switch    1
 
 zkerrbb  9     0.     1.e6      C_zkerrbb  add     0
 eta   " "        0.     0.     0.        1.0          1.0       -0.01
@@ -42,7 +69,7 @@ from sherpa.astro.xspec import XSAdditiveModel, get_xsversion
 from . import _models
 
 
-__all__ = ('XSagnslim', 'XSzkerrbb', )
+__all__ = ('XSagnslim', 'XSCph', 'XSvCph', 'XSzkerrbb', )
 
 
 # We need to ensure that the XSPEC model library has been initialized
@@ -141,6 +168,139 @@ class XSagnslim(XSAdditiveModel):
                 self.kTe_hot, self.kTe_warm, self.Gamma_hot, self.Gamma_warm,
                 self.R_hot, self.R_warm, self.logrout, self.rin,
                 self.redshift, self.norm)
+        XSAdditiveModel.__init__(self, name, pars)
+
+
+class XSCpH(XSAdditiveModel):
+    """The XSPEC CpH model: Cluster cooling+heating
+
+    See [1]_ for more information.
+
+    Attributes
+    ----------
+    peakT
+        The peak temperature, in keV
+    Abund
+        The abundance relative to solar
+    Redshift
+        The redshift of the gas
+    switch
+        0 for calculate, 1 for interpolate, 2 for AtomDB
+    norm
+        The mass-accretion rate, in solar masses/year.
+
+    See Also
+    --------
+    XSvCph
+
+    References
+    ----------
+
+    .. [1] https://github.com/HEASARC/xspec_localmodels/tree/master/cluscool
+
+    """
+
+    _calc = _models.C_cph
+
+    def __init__(self, name='cph'):
+        self.peakT = Parameter(name, 'peakT', 2.2, 0.1, 100, 0.1, 100,
+                               units='keV')
+        self.Abund = Parameter(name, 'Abund', 1, 0, 1000, 0, 1000,
+                               frozen=True)
+        self.Redshift = Parameter(name, 'Redshift', 1e-6, 1e-6, 50, 1e-6, 50,
+                                  frozen=True)
+        self.switch = Parameter(name, 'switch', 1, 0, 2, 0, 2,
+                                alwaysfrozen=True)
+        self.norm = Parameter(name, 'norm', 1.0, 0, 1e24, 0, hugeval)
+
+        pars = (self.peakT, self.Abund, self.Redshift, self.switch, self.norm)
+        XSAdditiveModel.__init__(self, name, pars)
+
+
+class XSvCpH(XSAdditiveModel):
+    """The XSPEC vCpH model: Cluster cooling+heating
+
+    See [1]_ for more information.
+
+    Attributes
+    ----------
+    peakT
+        The peak temperature, in keV
+    He
+        He abundance relative to solar.
+    C
+        C abundance relative to solar.
+    N
+        N abundance relative to solar.
+    O
+        O abundance relative to solar.
+    Ne
+        Ne abundance relative to solar.
+    Na
+        Na abundance relative to solar.
+    Mg
+        Mg abundance relative to solar.
+    Al
+        Al abundance relative to solar.
+    Si
+        Si abundance relative to solar.
+    S
+        S abundance relative to solar.
+    Ar
+        Ar abundance relative to solar.
+    Ca
+        Ca abundance relative to solar.
+    Fe
+        Fe abundance relative to solar.
+    Ni
+        Ni abundance relative to solar.
+    Redshift
+        The redshift of the gas
+    switch
+        0 for calculate, 1 for interpolate, 2 for AtomDB
+    norm
+        The mass-accretion rate, in solar masses/year.
+
+    See Also
+    --------
+    XSCph
+
+    References
+    ----------
+
+    .. [1] https://github.com/HEASARC/xspec_localmodels/tree/master/cluscool
+
+    """
+
+    _calc = _models.C_vcph
+
+    def __init__(self, name='vcph'):
+        self.peakT = Parameter(name, 'peakT', 2.2, 0.1, 100, 0.1, 100,
+                               units='keV')
+        self.He = Parameter(name, 'He', 1, 0, 1000, 0, 1000, frozen=True)
+        self.C = Parameter(name, 'C', 1, 0, 1000, 0, 1000, frozen=True)
+        self.N = Parameter(name, 'N', 1, 0, 1000, 0, 1000, frozen=True)
+        self.O = Parameter(name, 'O', 1, 0, 1000, 0, 1000, frozen=True)
+        self.Ne = Parameter(name, 'Ne', 1, 0, 1000, 0, 1000, frozen=True)
+        self.Na = Parameter(name, 'Na', 1, 0, 1000, 0, 1000, frozen=True)
+        self.Mg = Parameter(name, 'Mg', 1, 0, 1000, 0, 1000, frozen=True)
+        self.Al = Parameter(name, 'Al', 1, 0, 1000, 0, 1000, frozen=True)
+        self.Si = Parameter(name, 'Si', 1, 0, 1000, 0, 1000, frozen=True)
+        self.S = Parameter(name, 'S', 1, 0, 1000, 0, 1000, frozen=True)
+        self.Ar = Parameter(name, 'Ar', 1, 0, 1000, 0, 1000, frozen=True)
+        self.Ca = Parameter(name, 'Ca', 1, 0, 1000, 0, 1000, frozen=True)
+        self.Fe = Parameter(name, 'Fe', 1, 0, 1000, 0, 1000, frozen=True)
+        self.Ni = Parameter(name, 'Ni', 1, 0, 1000, 0, 1000, frozen=True)
+        self.Redshift = Parameter(name, 'Redshift', 1e-6, 1e-6, 50, 1e-6, 50,
+                                  frozen=True)
+        self.switch = Parameter(name, 'switch', 1, 0, 2, 0, 2,
+                                alwaysfrozen=True)
+        self.norm = Parameter(name, 'norm', 1.0, 0, 1e24, 0, hugeval)
+
+        pars = (self.peakT, self.He, self.C, self.N, self.O, self.Ne,
+                self.Na, self.Mg, self.Al, self.Si, self.S, self.Ar,
+                self.Ca, self.Fe, self.Ni,
+                self.Redshift, self.switch, self.norm)
         XSAdditiveModel.__init__(self, name, pars)
 
 

--- a/src/xspeclmodels/src/_models.cxx
+++ b/src/xspeclmodels/src/_models.cxx
@@ -7,6 +7,8 @@
 // At present limited to:
 //     zkerrbb.cxx (which calls zrunkbb.f)
 //     agnslim.f
+//     cluscool.cxx
+//     vcluscool.cxx
 //
 
 #include <iostream>
@@ -66,6 +68,32 @@ extern "C" {
 
   void agnslim_(float* ear, int* ne, float* param, int* ifl, float* photar, float* photer);
 
+  void cph(const RealArray& energyArray, const RealArray& params,
+	   int spectrumNumber, RealArray& flux, RealArray& fluxErr, 
+	   const string& initString);
+  void vcph(const RealArray& energyArray, const RealArray& params,
+	    int spectrumNumber, RealArray& flux, RealArray& fluxErr, 
+	    const string& initString);
+  
+  void C_cph(const double* energy, int nFlux, const double* params,
+	     int spectrumNumber, double* flux, double* fluxError,
+	     const char* initStr) {
+    const size_t nPar = 4;
+
+    cppModelWrapper(energy, nFlux, params, spectrumNumber, flux, fluxError,
+		    initStr, nPar, cph);
+  }
+
+  void C_vcph(const double* energy, int nFlux, const double* params,
+	      int spectrumNumber, double* flux, double* fluxError,
+	      const char* initStr) {
+    const size_t nPar = 17;
+
+    cppModelWrapper(energy, nFlux, params, spectrumNumber, flux, fluxError,
+		    initStr, nPar, vcph);
+  }
+
+
 }
 
 
@@ -74,6 +102,8 @@ static PyMethodDef Wrappers[] = {
   // for _NORM parameters.
   //
   XSPECMODELFCT_C_NORM( C_zkerrbb, 10 ),
+  XSPECMODELFCT_C_NORM( C_cph, 5 ),
+  XSPECMODELFCT_C_NORM( C_vcph, 18 ),
   XSPECMODELFCT_NORM( agnslim, 15 ),
 
   { NULL, NULL, 0, NULL }

--- a/src/xspeclmodels/src/cluscool.cxx
+++ b/src/xspeclmodels/src/cluscool.cxx
@@ -1,0 +1,42 @@
+#include <functionMap.h>
+#include <xsTypes.h>
+// #include <FunctionUtility.h>  // Changed by DJB
+#include <XSUtil/Numerics/Numerics.h>
+#include <XSUtil/Utils/XSutility.h>
+#include <iostream>
+#include <sstream>
+
+
+extern "C" void vcph(const RealArray& energyArray, const RealArray& params,
+	       int spectrumNumber, RealArray& flux, RealArray& fluxErr,
+	       const string& initString);
+
+
+extern "C" void cph(const RealArray& energyArray, const RealArray& params,
+	      int spectrumNumber, RealArray& flux, RealArray& fluxErr,
+	      const string& initString)
+{
+
+  //  XSPEC model subroutine to calculate modified cooling flow spectrum
+  //  from sum of spectra.
+  //  params array :
+  //        0..................peak temperature
+  //        1..................abundance
+  //        2..................redshift
+  //        3..................switch(0=calculate MEKAL model,
+  //                                  1=interpolate MEKAL model
+  //                                  2=APEC model)
+
+  //  Norm is mass accretion rate in units of Msun/yr
+
+
+  RealArray vparams(17);
+  vparams[0] = params[0];
+  vparams[1] = 1.0;
+  for (size_t i=2; i<15; i++) vparams[i] = params[1];
+  vparams[15] = params[2];
+  vparams[16] = params[3];
+  vcph(energyArray, vparams, spectrumNumber, flux, fluxErr, initString);
+
+  return;
+}

--- a/src/xspeclmodels/src/vcluscool.cxx
+++ b/src/xspeclmodels/src/vcluscool.cxx
@@ -1,0 +1,215 @@
+//=======================This code is for a Cooling+Heating model with constant pressure.======================//
+
+#include <functionMap.h>
+#include <xsTypes.h>
+// #include <FunctionUtility.h>
+#include <XSFunctions/Utilities/FunctionUtility.h> // changed by DJB
+#include <XSUtil/Numerics/Numerics.h>
+#include <XSUtil/Utils/XSutility.h>
+#include <iostream>
+#include <sstream>
+
+#define keVtoK 1.1604505e7
+
+// function definitions in pfltmp.cxx, pflbol.cxx, and calcMultiTempPlasma.cxx
+//
+// DJB asks: where are pfltmp and pflbol defined? I can't find them
+// in heasoft-6.25/Xspec/ or heasoft-6.26.1/Xspec/
+//
+void pfltmp(int itype, float** tval, int* nmtval, int* status);
+void pflbol(int itype, const float* abun, float* bolo, int* status);
+int calcMultiTempPlasma(const RealArray& energyArray, const int plasmaType,
+                        const IntegerArray& Zarray, const RealArray& abun,
+                        const Real dens, const Real z, const RealArray& Tarr,
+                        const RealArray& DEMarr, const int ifl, const bool qtherm,
+                        const Real velocity, RealArray& fluxArray,
+                        RealArray& fluxErrArray);
+
+
+extern "C" void vcph(const RealArray& energyArray, const RealArray& params,
+		     int spectrumNumber, RealArray& flux, RealArray& fluxErr,
+		     const string& initString)
+{
+
+  //  XSPEC model subroutine to calculate modified cooling flow spectrum
+  //  from sum of spectra. Variable abundances.
+  //  params array :
+  //        0..................peak temperature
+  //        1..................He abundance
+  //        2..................C     "
+  //        3..................N     "
+  //        4..................O     "
+  //        5..................Ne    "
+  //        6..................Na    "
+  //        7..................Mg    "
+  //        8..................Al    "
+  //        9..................Si    "
+  //       10..................S     "
+  //       11..................Ar    "
+  //       12..................Ca    "
+  //       13..................Fe    "
+  //       14..................Ni    "
+  //       15..................redshift
+  //       16..................switch(0=calculate MEKAL model,
+  //                                  1=interpolate MEKAL model
+  //                                  2=APEC model)
+
+  //  Norm is mass accretion rate in units of Msun/yr
+
+
+  using namespace XSutility;
+
+  const int elements[] = {2, 6, 7, 8, 10, 11, 12, 13, 14, 16, 18, 20, 26, 28};
+  IntegerArray Zarray(14);
+  for (size_t i=0; i<14; i++) Zarray[i] = elements[i];
+
+  const size_t nE = energyArray.size()-1;
+  flux.resize(nE);
+  fluxErr.resize(0);
+
+
+  // On initialization find the tabulated temperatures and calculate the
+  // bolometric luminosities for each temperature.
+
+  static bool isFirst = true;
+  static float *ttab=0; // This memory is owned in ldpfil
+  static int nmtval=0;
+  static auto_array_ptr<float> apBolo(0);
+  int status = 0;
+  int itype = 2;
+  if (isFirst) {
+    pfltmp(itype, &ttab, &nmtval, &status);
+    if (status) return;
+    float *oldF = apBolo.reset(new float[nmtval]);
+    delete [] oldF;
+  }
+
+  // Calculate the bolometric luminosities
+  float *abunParam = new float[14];
+  for (size_t i=0; i<14; i++) abunParam[i] = params[i+1];
+  pflbol(itype, abunParam, apBolo.get(), &status);
+  if (status) return;
+  delete [] abunParam;
+
+  // Get the number of temperature steps.
+  // Here is my changes in the nsteps
+  Real tlow = 0.01;
+  Real thigh = 50.0;
+  Real altlow = log(tlow);
+  Real althigh = log(thigh);
+  float dlogT = 0.1;
+
+  int nsteps = (althigh-altlow)/dlogT;
+
+
+
+  Real slope = 0.0;
+  RealArray abun(14);
+  for (size_t i=0; i<14; i++) abun[i] = params[i+1];
+  Real dens = 1.0;
+  Real z = params[15];
+  Real tpeak = params[0];
+  Real sqrtTpeak5K = pow(keVtoK*tpeak,2.5);
+  int switchPar = static_cast<int>(params[16]);
+
+  if ( z <= 0.0 ) {
+    FunctionUtility::xsWrite("\n VCLUSCOOL: Require z > 0 for cooling flow models",10);
+    return;
+  }
+
+  int plasmaType;
+  if ( switchPar == 0 || switchPar == 1) {
+    plasmaType = switchPar + 3;
+  } else if ( switchPar == 2 ) {
+    plasmaType = switchPar + 4;
+  } else {
+    FunctionUtility::xsWrite("\n VCLUSCOOL: Invalid switch parameter value",2);
+    FunctionUtility::xsWrite("            Must be 0, 1, or 2",2);
+    return;
+  }
+
+  // Set up the temperature array
+
+
+  RealArray tval(nsteps);
+  for (size_t i=0; i<nsteps; i++) {
+    tval[i] = exp(altlow + i*(althigh-altlow)/(nsteps-1));
+  }
+
+  // Get the cosmology parameters
+
+  Real q0 = FunctionUtility::getq0();
+  Real h0 = FunctionUtility::getH0();
+  Real Lambda0 = FunctionUtility::getlambda0();
+
+  // Fix up the norm. The numerical constant assumes distance linearly depends
+  // on redshift with H0=50 hence cosmology factors correct this.
+
+  Numerics::FZSQ fzsq;
+  Real norm = 3.16e-15 * (h0/50.)*(h0/50.) / fzsq(z, q0, Lambda0);
+
+
+
+  //  Now calculate the DEMs. The integral is an extended trapezium rule
+  //  over the temperatures. The integration is performed in log T space.
+
+  RealArray dem(nsteps);
+  for (size_t i=0; i<nsteps; i++) dem[i] = 0.0;
+
+  // Loop over all the temperatures
+
+  for ( size_t i=0; i<nsteps; i++) {
+
+    Real tkeV = tval[i];
+
+    Real factor = (althigh-altlow)/(nsteps-1);
+    if ( i == 0 || i == nsteps-1 ) factor = factor/2.;
+
+    //  Interpolate on the tabulated array of bolometric luminosities to
+    //  get the value for this temperature
+
+    Real boloi;
+    if ( tkeV <= ttab[0] ) {
+      boloi = apBolo.get()[0];
+    } else if ( tkeV >= ttab[nmtval-1] ) {
+      boloi = apBolo.get()[nmtval-1];
+    } else {
+      size_t j = 0;
+      while ( tkeV > ttab[j+1] ) j++;
+      boloi = ( apBolo.get()[j]*(ttab[j+1]-tkeV) + apBolo.get()[j+1]*(tkeV-ttab[j]) )
+	/ (ttab[j+1]-ttab[j]);
+    }
+
+
+    //  calculate the emission-weighting for this temperature. This
+    //  includes the division by the bolometric emissivity and an
+    //  extra factor of T since we are integrating in log space.
+
+    Real tstep = keVtoK*tval[i];
+    dem[i] = pow((tstep/1.e7),slope) * tstep * factor * norm / boloi;
+
+// Here tpeak is T* in Zhoolideh Haghighi et al. 2018.
+// Interpolate on the tabulated array of bolometric luminosities to
+
+    Real sqrtTstep5 = pow(tstep,2.5);
+    Real tpeakBolo;
+    if ( tpeak <= ttab[0] ) {
+      tpeakBolo = apBolo.get()[0];
+    } else if ( tpeak >= ttab[nmtval-1] ) {
+      tpeakBolo = apBolo.get()[nmtval-1];
+    } else {
+      size_t j = 0;
+      while ( tpeak > ttab[j+1] ) j++;
+      tpeakBolo = ( apBolo.get()[j]*(ttab[j+1]-tpeak) + apBolo.get()[j+1]*(tpeak-ttab[j]) )
+	/ (ttab[j+1]-ttab[j]);
+    }
+
+    dem[i] *= 1./fabs(1-sqrtTstep5/boloi/(sqrtTpeak5K/tpeakBolo));
+
+  }
+
+  calcMultiTempPlasma(energyArray, plasmaType, Zarray, abun, dens, z,
+		      tval, dem, spectrumNumber, false, 0.0, flux, fluxErr);
+
+   isFirst = false;
+}


### PR DESCRIPTION
The two cluscool models require symbols that I can not find in HEASOFT
6.25 or 6.26.1: pfltmp() and pflbol(). Are these routines that have
been renamed or removed in XSPEC 12.10.1?

This PR is left for posterity / until I can find out what has happened to these models.
Actually, they are in XSPEC 12.10.1 so we already have them in CIAO 4.12.
